### PR TITLE
Added required models for preparing benchmark according to Zeng 2025

### DIFF
--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -39,6 +39,7 @@ end
 @publish PhysicalModels NonlinearNeoHookean_CV
 @publish PhysicalModels NonlinearMooneyRivlin_CV
 @publish PhysicalModels NonlinearIncompressibleMooneyRivlin2D_CV
+@publish PhysicalModels EightChain
 @publish PhysicalModels TransverseIsotropy3D
 @publish PhysicalModels TransverseIsotropy2D
 @publish PhysicalModels ThermalModel


### PR DESCRIPTION
**Description**
- Added eight-chain model from Arruda & Boyce 1993
- Changed `VolumetricEnergy` from `Mechano` to `Elasto`
- Added elastic models composition (`+`)

Note: it makes no sense to add a test for the eight-chain model because its derivatives are numerical.