### PR TITLE
Analytical derivatives for eight-chain model

### DIFF
--- a/test/TestConstitutiveModels/PhysicalModels.jl
+++ b/test/TestConstitutiveModels/PhysicalModels.jl
@@ -707,12 +707,6 @@ end
 @testset "Hessian∇JRegularization" begin
   ∇u = TensorValue(1.0, 2.0, 3.0, 4.0) * 1e-3
   ∇u0 = TensorValue(1.0, 2.0, 3.0, 4.0) * 0.0
-
-  μParams = [6456.9137547089595, 896.4633794151492,
-    1.999999451256222,
-    1.9999960497608036,
-    11747.646562400318,
-    0.7841068624959612, 1.5386288924587603]
   model = ARAP2D(μ=μParams[1])
   modelreg = Hessian∇JRegularization(Mechano=model)
 

--- a/test/TestConstitutiveModels/PhysicalModels.jl
+++ b/test/TestConstitutiveModels/PhysicalModels.jl
@@ -141,6 +141,12 @@ end
 end
 
 
+@testset "EightChain" begin
+  model = EightChain(μ=μParams[1], N=μParams[2])
+  test_derivatives_3D_(model, rtol=1e-13)
+end
+
+
 @testset "TransverseIsotropy2D" begin
   ∇u = TensorValue(1.0, 2.0, 3.0, 4.0) * 1e-3
   ∇u0 = TensorValue(1.0, 2.0, 3.0, 4.0) * 0.0


### PR DESCRIPTION
Hi @jmartfrut and @RogelioOrtigosa , thanks for sharing the analytical derivatives. Here it is the implementation.

I've added a tool for easing fast benchamrks. In the future it could be moved to a new file. A possible output is
```
Analyitical ∂Ψu  |   93.572 ns (0 allocations: 0 bytes)
Numerical ∂Ψu    |   168.590 ns (0 allocations: 0 bytes)
Analyitical ∂Ψuu |   295.935 ns (0 allocations: 0 bytes)
Numerical ∂Ψuu   |   4.414 μs (85 allocations: 3.27 KiB)
```

**Changelog**
- Added derivatives implementation
- Added test for eight-chain model
- Removed warning related to redefinition of a variable
- Added function prototype for benchmarking (it should be moved to a new file)