### PR TITLE
Tools for viscoelasticity

### DIFF
--- a/src/ComputationalModels/BoundaryConditions.jl
+++ b/src/ComputationalModels/BoundaryConditions.jl
@@ -139,6 +139,15 @@ end
 
 function residual_Neumann(::NothingBC, kwargs...) end
 
+"""
+    residual_Neumann(...)::Function
+
+Return the Neumann residual as a FUNCTION.
+"""
+function residual_Neumann(bc::NeumannBC, dΓ::Vector, Λ::Float64)
+    v -> mapreduce((fi, dΓi) -> ∫(v ⋅ fi(Λ))dΓi, +, bc.values, dΓ)
+end
+
 function residual_Neumann(bc::NeumannBC, v, dΓ, Λ)
     bc_func_ = Vector{Function}(undef, length(bc.tags))
     for (i, f) in enumerate(bc.values)

--- a/src/ComputationalModels/BoundaryConditions.jl
+++ b/src/ComputationalModels/BoundaryConditions.jl
@@ -164,20 +164,22 @@ function residual_Neumann(bc::NeumannBC, v, dΓ, Λ⁺, Λ⁻)
     return mapreduce(f -> f(v), +, bc_func_)
 end
 
-function get_Neumann_dΓ(model, ::NothingBC, degree)
+"""
+    get_Neumann_dΓ(...)::Vector{Gridap.CellData.GenericMeasure}
+
+Return a collection of boundary triangulations at the specified Neumann boundaries.
+"""
+function get_Neumann_dΓ(model, ::NothingBC, degree::Int)
     Vector{Gridap.CellData.GenericMeasure}(undef, 1)
 end
 
-function get_Neumann_dΓ(model, bc::NeumannBC, degree)
-    dΓ = Vector{Gridap.CellData.GenericMeasure}(undef, length(bc.tags))
-    for i in 1:length(bc.tags)
-        Γ = BoundaryTriangulation(model, tags=bc.tags[i])
-        dΓ[i] = Measure(Γ, degree)
-    end
-    return dΓ
+function get_Neumann_dΓ(model, bc::NeumannBC, degree::Int)
+    all_Γ = map(tag -> BoundaryTriangulation(model, tags=tag), bc.tags)
+    all_dΓ = map(Γi -> Measure(Γi, degree), all_Γ)
+    all_dΓ
 end
 
-function get_Neumann_dΓ(model, bc::MultiFieldBC, degree::Int64)
+function get_Neumann_dΓ(model, bc::MultiFieldBC, degree::Int)
     dΓ = Vector{Vector{Gridap.CellData.GenericMeasure}}(undef, length(bc.BoundaryCondition))
     for (i, bc_i) in enumerate(bc.BoundaryCondition)
         dΓ[i] = get_Neumann_dΓ(model, bc_i, degree)


### PR DESCRIPTION
Some useful tools for visco-elastic problems:k,

- `get_Neumann_dΓ`: Added docstring and conciser implementation. No changes in API changes.
- `residual_Neumann`: Added signature without test function. The returned value is a callable compatible with Gridap functions. Documented in docstrings.
- `PostProcessor.Cauchy`: Added signature with visco-elastic model.
- `WeakForms.residual/jacobian`: Added methods. The returned values are callable functions compatible with Gridap functions.