### PR TITLE
Gridap compatibility: `residual`, `jacobian`, `solve!`

### DIFF
--- a/src/ComputationalModels/ComputationalModels.jl
+++ b/src/ComputationalModels/ComputationalModels.jl
@@ -9,6 +9,7 @@ using Gridap.TensorValues, Gridap.FESpaces, Gridap.Algebra
 using Gridap: createvtk
 using Gridap.MultiField
 using Gridap.FESpaces: get_assembly_strategy
+import Gridap: solve!
 
 using BlockArrays
 using GridapPETSc, GridapPETSc.PETSC

--- a/src/WeakForms/WeakForms.jl
+++ b/src/WeakForms/WeakForms.jl
@@ -9,8 +9,10 @@ export jacobian
 export mass_term
 export (+)
 
+import Gridap.Algebra:residual,jacobian
 import Base: +
 
+# ===================
 # Coupling management
 # ===================
 


### PR DESCRIPTION
In order to make multiple dispatch to work, the functions to be extended need to be imported