### PR TITLE
[Step 1/3] Dependencies for benchmark

### DIFF
--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"


### PR DESCRIPTION
In PR #16 and #17, the compilation of main is still failing before running benchmarks.

This PR attempts to fix the compilation of main branch before incorporating the CI for benchmarks.