### PR TITLE
[Misc] [`IO.setupfolder`] Avoid error if folder does not exist

### DIFF
--- a/src/Io.jl
+++ b/src/Io.jl
@@ -1,8 +1,33 @@
-function setupfolder(folder_path::String)
-    if !isdir(folder_path)
-      mkdir(folder_path)
-    else
-      rm(folder_path,recursive=true)
-      mkdir(folder_path)
-    end
+"""
+Make sure the specified folder exists.
+
+# Examples
+    setupfolder("output")                    # Remove everything inside "output"
+    setupfolder("output", ".*")              # Remove everything inside "output"
+    setupfolder("output", "all")             # Remove everything inside "output"
+    setupfolder("results", ".vtu")           # Remove only .vtu files
+    setupfolder("results", [".vtu", ".pvd"]) # Remove multiple file types
+    setupfolder("data", nothing)             # Keep existing contents
+    setupfolder("data", remove=nothing)      # Keep existing contents
+"""
+function setupfolder(path::String; remove::Any="all")
+  if isdir(path)
+    cleandir(path, remove)
   end
+  mkpath(path)
+end
+
+function cleandir(path::String, remove::String)
+  if remove === "all"
+    rm(path,recursive=true)
+  else
+    foreach(rm, filter(endswith(remove), readdir(path,join=true)))
+  end
+end
+
+function cleandir(path::String, remove::AbstractVector{String})
+  foreach(r -> cleandir(path,r), remove)
+end
+
+function cleandir(::String, ::Nothing)
+end


### PR DESCRIPTION
At the first run, the full path may not exist. If so, `mkdir` will throw an error. Additionally, `setupfolder` may remove outputs when performing sensitivity analysis.

**Changelog**
- Fixed error when folder does not exist
- Added option to select what to remove (current behaviour is preserved)