### PR TITLE
[Post-process] Added metrics

### DIFF
--- a/src/ComputationalModels/ComputationalModels.jl
+++ b/src/ComputationalModels/ComputationalModels.jl
@@ -83,6 +83,7 @@ export get_test_space
 include("PostProcessors.jl")
 export PostProcessor
 export Cauchy
+export Jacobian
 export Entropy
 export D0
 export reset!

--- a/src/ComputationalModels/PostMetrics.jl
+++ b/src/ComputationalModels/PostMetrics.jl
@@ -1,0 +1,42 @@
+module PostMetrics
+
+using Gridap
+using HyperFEM.PhysicalModels
+
+"""
+    component_LInf(::FEFunction, ::Symbol, ::Triangulation)::Float64
+
+Calculate the L-inf norm of a vector-valued finite element function.
+It could be useful to find the maximum displacement.
+
+# Example
+    x_max = component_LInf(uh, :x, Ω)
+"""
+function component_LInf(u, dir, Ω)
+  if     dir === :x
+    n = VectorValue(1.0, 0.0, 0.0)
+  elseif dir === :y
+    n = VectorValue(0.0, 1.0, 0.0)
+  elseif dir === :z
+    n = VectorValue(0.0, 0.0, 1.0)
+  else
+    throw("Direction must be either :x, :y or :z. Got $dir")
+  end
+  reffe = ReferenceFE(lagrangian, Float64, 1)
+  V = FESpace(Ω, reffe, conformity=:L2)
+  un = interpolate_everywhere(u⋅n, V)
+  uall = [un.free_values; un.dirichlet_values]
+  norm(uall, Inf)
+end
+
+
+"""
+Calculate the variation of the volume with respect to the undeformed configuration.
+"""
+function volume_diff(uh, dΩ)
+  F, _, J = Kinematics(Mechano).metrics
+  sum(∫(J ∘ F ∘ ∇(uh) -1.0)dΩ) / sum(∫(1.0)dΩ)
+end
+
+
+end

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -113,6 +113,7 @@ end
 @publish ComputationalModels  PostProcessor
 @publish ComputationalModels  StaggeredModel
 @publish ComputationalModels  Cauchy
+@publish ComputationalModels  Jacobian
 @publish ComputationalModels  Entropy
 @publish ComputationalModels  D0
 @publish ComputationalModels  reset!


### PR DESCRIPTION
Added several tools for fast post-processing. Those tools are useful for generating plots after a simulation and *performing tests*, e.g.:

```jl
tip_displacement = Float64[]
...
function PostProcessor(...)
  push!(component_LInf(uh, z:, Ω), tip_displacement)
  ...
end
...
solve!(...)
plot(t, tip_displacement)
@test tip_displacement[end] ≈ 0.02564832
```