### PR TITLE
Modifies αr to be passed as a Reference

### DIFF
--- a/src/PhysicalModels/MagneticModels.jl
+++ b/src/PhysicalModels/MagneticModels.jl
@@ -4,24 +4,25 @@
 # ===================
 
 
-struct Magnetic{A} <: Magneto
+struct Magnetic <: Magneto
   μ::Float64
-  αr::Float64
+  αr::Ref{Float64}
   χe::Float64
-  Kinematic::A
-  function Magnetic(; μ::Float64, αr::Float64, χe::Float64=0.0, Kinematic::KinematicModel=Kinematics(Magneto))
-    new{typeof(Kinematic)}(μ, αr, χe, Kinematic)
-  end
-  function (obj::Magnetic)(Λ::Float64=1.0)
-    μ, αr, χe = obj.μ,  obj.αr, obj.χe
-    αr *= Λ
-    ℋᵣ(N) = αr * N
-    # Energy #
-    Ψmm(ℋ₀,N)      = (-μ  / 2.0 ) * ((ℋ₀+ℋᵣ(N))⋅(ℋ₀+ℋᵣ(N))) * (1 + χe)
-    ∂Ψmm_∂φ(ℋ₀,N)  = (-μ ) * (ℋ₀+ℋᵣ(N)) * (1 + χe)
-    ∂Ψmm_∂φφ(ℋ₀,N) = (-μ ) * I3 * (1 + χe)
-    return (Ψmm, ∂Ψmm_∂φ, ∂Ψmm_∂φφ)
-  end
+  Kinematic::Kinematics{Magneto}
+  
+function Magnetic(; μ::Float64, αr::Ref{Float64}, χe::Float64=0.0, Kinematic::Kinematics{Magneto}=Kinematics(Magneto))
+  new(μ, αr, χe, Kinematic)
+end
+function (obj::Magnetic)(Λ::Float64=1.0)
+  μ, αr, χe = obj.μ, obj.αr, obj.χe
+  ℋᵣ(N) = αr[] * Λ * N
+  # Energy #
+  Ψmm(ℋ₀, N) = (-μ / 2.0) * ((ℋ₀ + ℋᵣ(N)) ⋅ (ℋ₀ + ℋᵣ(N))) * (1 + χe)
+  ∂Ψmm_∂φ(ℋ₀, N) = (-μ) * (ℋ₀ + ℋᵣ(N)) * (1 + χe)
+  ∂Ψmm_∂φφ(ℋ₀, N) = (-μ) * I3 * (1 + χe)
+  return (Ψmm, ∂Ψmm_∂φ, ∂Ψmm_∂φφ)
+end
+
 
 end
 

--- a/test/TestConstitutiveModels/PhysicalModelTests.jl
+++ b/test/TestConstitutiveModels/PhysicalModelTests.jl
@@ -509,7 +509,9 @@ end
 
 @testset "Magnetic" begin
   ∇φ = VectorValue(1.0, 2.0, 3.0)
-  modelID = Magnetic(μ=1.2566e-6, αr=40e-3 ,χe=0.0)
+  a=40e-3 
+  ra=Ref(a)
+  modelID = Magnetic(μ=1.2566e-6, αr=ra ,χe=0.0)
   Ψ, ∂Ψφ, ∂Ψφφ = modelID()
   H0 = get_Kinematics(modelID.Kinematic)
   N = VectorValue(0.0, 0.0, 1.0)


### PR DESCRIPTION
Changes the Magnetic struct to accept αr as a Ref{Float64}.

This allows for external modification of the αr parameter, enabling dynamic adjustments and simplifying parameter updates without reconstructing the entire Magnetic object.