### PR TITLE
Allow @. syntax for vectorized evaluation with single constitutive model

### DIFF
--- a/src/PhysicalModels/PhysicalModels.jl
+++ b/src/PhysicalModels/PhysicalModels.jl
@@ -148,6 +148,8 @@ include("PINNs.jl")
 # Physical models interface
 # ============================================
 
+Base.broadcastable(m::PhysicalModel) = Ref(m) # Allows to use the @. syntax for passing a single constitutive model into a vectorized function
+
 """
 Initialize the state variables for the given constitutive model and discretization.
 """

--- a/test/TestConstitutiveModels/PhysicalModelTests.jl
+++ b/test/TestConstitutiveModels/PhysicalModelTests.jl
@@ -945,9 +945,6 @@ end
 end
 
 
-
-
-
 @testset "Hessian∇JRegularization" begin
   #  4.09 μs      Histogram: log(frequency) by time      10.8 μs <
   #  Memory estimate: 2.58 KiB, allocs estimate: 11.
@@ -976,4 +973,16 @@ end
 end
 
 
+@testset "broadcastable" begin
+  model = LinearElasticity3D(λ=3.0, μ=1.0)
+  _, P, _ = model()
+  function evaluate_stress(model, λ1, λ2)
+    F = TensorValue(λ1, 0, 0, 0, λ2, 0, 0, 0, 1/(λ1*λ2))
+    return P(F)[1]
+  end
+  λ1_vals = [1, 1]
+  λ2_vals = [1, 1]
+  P_vals = @. evaluate_stress(model, λ1_vals', λ2_vals)
+  @test P_vals == [0.0 0.0; 0.0 0.0]
+end
 


### PR DESCRIPTION
By default, the `@.` macro interprets non-simplex types as iterables. It means that it'll try to iterate a single constitutive model.

The proposed implementation allows to evaluate vectorized functions where a constitutive model is passed.

# Examples of usage
```julia
v = 0.05
θ_vals_cv  = 1:50:2.06θr
λ_vals_cv  = 1:0.5:8.0
cv_vals_cv = @. evaluate_cv(model, θ_vals_cv, λ_vals_cv', v)
p = plot(title="Specific heat under isochoric stretch, v=$v/s", xlabel="Stretch [-]", ylabel="θ/θR [-]", rightmargin=8mm, framestyle=:grid)
contourf!(λ_vals_cv, θ_vals_cv./θr, cv_vals_cv, color=diverging_rb, clims=(-cv_lim, cv_lim), lw=0, lc=:transparent)
```

I've simplified the code a little, it should produce a map like this:

<img width="886" height="591" alt="image" src="https://github.com/user-attachments/assets/9317c61b-fcfe-407a-bc63-dc9c2df42f87" />

# Errors fixed

When the `broadcastable` dispatch is missing, the `@.` macro may throw an error like this:
```
broadcastable: Error During Test at c:\Users\Miguel\source\repos\HyperFEM\test\TestConstitutiveModels\PhysicalModelTests.jl:976
  Got exception outside of a @test
  MethodError: no method matching length(::LinearElasticity3D)
  The function `length` exists, but no method is defined for this combination of argument types.

  Closest candidates are:
    length(::DataStructures.SparseIntSet)
     @ DataStructures C:\Users\Miguel\.julia\packages\DataStructures\qUuAY\src\sparse_int_set.jl:61
    length(::DataStructures.DiBitVector)
     @ DataStructures C:\Users\Miguel\.julia\packages\DataStructures\qUuAY\src\dibit_vector.jl:40
    length(::Profile.HeapSnapshot.Edges)
     @ Profile C:\Users\Miguel\.julia\juliaup\julia-1.12.4+0.x64.w64.mingw32\share\julia\stdlib\v1.12\Profile\src\heapsnapshot_reassemble.jl:24
    ...

  Stacktrace:
    [1] _similar_shape(itr::LinearElasticity3D, ::Base.HasLength)
      @ Base .\array.jl:657
    [2] _collect(cont::UnitRange{Int64}, itr::LinearElasticity3D, ::Base.HasEltype, isz::Base.HasLength)
      @ Base .\array.jl:734
    [3] collect(itr::LinearElasticity3D)
      @ Base .\array.jl:728
    [4] broadcastable(x::LinearElasticity3D)
      @ Base.Broadcast .\broadcast.jl:733
```