### PR TITLE
Support multi-physics in injectivity-preserving line search

### DIFF
--- a/src/Solvers/LineSearches.jl
+++ b/src/Solvers/LineSearches.jl
@@ -63,16 +63,17 @@ struct Injectivity_Preserving_LS{A} <: AbstractLineSearch
   ρ::Float64
   c::Float64
   β::CellField
+  maskphys::Int64
   caches::A
-  function Injectivity_Preserving_LS(α::CellState, U, V; maxiter::Int64=50, αmin::Float64=1e-16, ρ::Float64=0.5, c::Float64=0.95, β::Float64=0.95)
+  function Injectivity_Preserving_LS(α::CellState, U, V; maxiter::Int64=50, αmin::Float64=1e-16, ρ::Float64=0.5, c::Float64=0.95, β::Float64=0.95, maskphys::Int64=0)
     caches = (U, V)
-    new{typeof(caches)}(α, maxiter, αmin, ρ, c, CellField(β, α.points.trian), caches)
+    new{typeof(caches)}(α, maxiter, αmin, ρ, c, CellField(β, α.points.trian), maskphys, caches)
   end
- 
+
 
   function (obj::Injectivity_Preserving_LS)(x::AbstractVector, dx::AbstractVector, b::AbstractVector, op::NonlinearOperator)
 
-    _, maxiter, αmin, ρ, c= obj.α, obj.maxiter, obj.αmin, obj.ρ, obj.c
+    _, maxiter, αmin, ρ, c = obj.α, obj.maxiter, obj.αmin, obj.ρ, obj.c
     #update cell state
     U, V = obj.caches
     xh = FEFunction(U, x)
@@ -84,7 +85,7 @@ struct Injectivity_Preserving_LS{A} <: AbstractLineSearch
     while α > αmin && m < maxiter
       residual!(b, op, x + α * dx)
       R = b' * dx
-      if R <= c * R₀
+      if abs(R) <= abs(c * R₀)
         break
       end
       α *= ρ
@@ -96,19 +97,26 @@ struct Injectivity_Preserving_LS{A} <: AbstractLineSearch
 end
 
 function InjectivityCheck(α, ∇u, ∇du, β)
-  ε = 1e-6
+  # ε = 1e-6
   F = ∇u + one(∇u)
   J = det(F)
   H = J * inv(F)'
   # if det(F+∇du) < 0.2
   # @show det(F), det(F+∇du)
   # end
-  return true, min(β*abs(( -J) / (det(∇du) + tr(H' * ∇du) )), 1.0)
+  return true, min(β * abs((-J) / (det(∇du) + tr(H' * ∇du))), 1.0)
 
 end
-
 
 function update_cellstate!(obj::Injectivity_Preserving_LS, xh, dxh)
-  update_state!(InjectivityCheck, obj.α, ∇(xh)', ∇(dxh)', obj.β)
+  uh = obj.maskphys == 0 ? xh : xh[obj.maskphys]
+  duh = obj.maskphys == 0 ? dxh : dxh[obj.maskphys]
+  update_state!(InjectivityCheck, obj.α, ∇(uh)', ∇(duh)', obj.β)
   return minimum(minimum((obj.α.values)))
 end
+
+
+# function update_cellstate!(obj::Injectivity_Preserving_LS, xh, dxh)
+#   update_state!(InjectivityCheck, obj.α, ∇(xh)', ∇(dxh)', obj.β)
+#   return minimum(minimum((obj.α.values)))
+# end


### PR DESCRIPTION
Adds a `maskphys` field to filter specific physics components for injectivity checks in multi-physics models. Additionally, the line search termination condition now uses absolute values to correctly handle residual comparisons.