### PR TITLE
Consistent cartesian tags

### DIFF
--- a/src/ComputationalModels/CartesianTags.jl
+++ b/src/ComputationalModels/CartesianTags.jl
@@ -2,24 +2,27 @@
 "Shortcuts for the tags of cartesian discrete models."
 module CartesianTags
 
-"Tags indicating points, edges and faces at plane X0."
-const faceX0 = [1, 3, 5, 7, 13, 15, 17, 19, 25]
+# --- Face tags ---
 
-"Tags indicating points, edges and faces at plane X1."
-const faceX1 = [2, 4, 6, 8, 14, 16, 18, 20, 26]
+"Tags indicating the face at plane X0."
+const face0YZ = [25]
 
-"Tags indicating points, edges and faces at plane Y0."
-const faceY0 = [1, 2, 5, 6, 9, 11, 17, 18, 23]
+"Tags indicating the face at plane X1."
+const face1YZ = [26]
 
-"Tags indicating points, edges and faces at plane Y1."
-const faceY1 = [3, 4, 7, 8, 10, 12, 19, 20, 24]
+"Tags indicating the face at plane Y0."
+const faceX0Z = [23]
 
-"Tags indicating points, edges and faces at plane Z0."
-const faceZ0 = [1, 2, 3, 4, 9, 10, 13, 14, 21]
+"Tags indicating the face at plane Y1."
+const faceX1Z = [24]
 
-"Tags indicating points, edges and faces at plane Z1."
-const faceZ1 = [5, 6, 7, 8, 11, 12, 15, 16, 22]
+"Tags indicating the face at plane Z0."
+const faceXY0 = [21]
 
+"Tags indicating the face at plane Z1."
+const faceXY1 = [22]
+
+# --- Edge tags ---
 
 "Tag indicating the edge at  X, Y0, Z0."
 const edgeX00 = [9]
@@ -57,6 +60,7 @@ const edge01Z = [19]
 "Tag indicating the edge at  X1, Y1, Z."
 const edge11Z = [20]
 
+# --- Corner tags ---
 
 "Tag indicating the point at corner X0, Y0, Z0."
 const corner000 = [1]
@@ -81,4 +85,72 @@ const corner011 = [7]
 
 "Tag indicating the point at corner X1, Y1, Z1."
 const corner111 = [8]
+
+# --- Edge & corner tags ---
+
+"Tags indicating points and edge at X, Y0, Z0."
+const edgeX00⁺ = [edgeX00; corner000; corner100]
+
+"Tags indicating points and edge at X, Y1, Z0."
+const edgeX10⁺ = [edgeX10; corner010; corner110]
+
+"Tags indicating points and edge at X, Y0, Z1."
+const edgeX01⁺ = [edgeX01; corner001; corner101]
+
+"Tags indicating points and edge at X, Y1, Z1."
+const edgeX11⁺ = [edgeX11; corner011; corner111]
+
+"Tags indicating points and edge at X0, Y, Z0."
+const edge0Y0⁺ = [edge0Y0; corner000; corner010]
+
+"Tags indicating points and edge at X1, Y, Z0."
+const edge1Y0⁺ = [edge1Y0; corner100; corner110]
+
+"Tags indicating points and edge at X0, Y, Z1."
+const edge0Y1⁺ = [edge0Y1; corner001; corner011]
+
+"Tags indicating points and edge at X1, Y, Z1."
+const edge1Y1⁺ = [edge1Y1; corner101; corner111]
+
+"Tags indicating points and edge at X0, Y0, Z."
+const edge00Z⁺ = [edge00Z; corner000; corner001]
+
+"Tags indicating points and edge at X1, Y0, Z."
+const edge10Z⁺ = [edge10Z; corner100; corner101]
+
+"Tags indicating points and edge at X0, Y1, Z."
+const edge01Z⁺ = [edge01Z; corner010; corner011]
+
+"Tags indicating points and edge at X1, Y1, Z."
+const edge11Z⁺ = [edge11Z; corner110; corner111]
+
+# --- Face & edge & corner tags ---
+
+"Tags indicating points, edges and faces at plane X0."
+const face0YZ⁺ = [face0YZ; edge00Z⁺; edge01Z⁺; edge0Y0⁺; edge0Y1⁺]
+
+"Tags indicating points, edges and faces at plane X1."
+const face1YZ⁺ = [face1YZ; edge10Z⁺; edge11Z⁺; edge1Y0⁺; edge1Y1⁺]
+
+"Tags indicating points, edges and faces at plane Y0."
+const faceX0Z⁺ = [faceX0Z; edgeX00⁺; edgeX01⁺; edge00Z⁺; edge10Z⁺]
+
+"Tags indicating points, edges and faces at plane Y1."
+const faceX1Z⁺ = [faceX1Z; edgeX10⁺; edgeX11⁺; edge01Z⁺; edge11Z⁺]
+
+"Tags indicating points, edges and faces at plane Z0."
+const faceXY0⁺ = [faceXY0; edgeX00⁺; edgeX10⁺; edge0Y0⁺; edge1Y0⁺]
+
+"Tags indicating points, edges and faces at plane Z1."
+const faceXY1⁺ = [faceXY1; edgeX01⁺; edgeX11⁺; edge0Y1⁺; edge1Y1⁺]
+
+# --- Deprecations ---
+
+Base.@deprecate_binding faceX0 face0YZ
+Base.@deprecate_binding faceX1 face1YZ
+Base.@deprecate_binding faceY0 faceX0Z
+Base.@deprecate_binding faceY1 faceX1Z
+Base.@deprecate_binding faceZ0 faceXY0
+Base.@deprecate_binding faceZ1 faceXY1
+
 end

--- a/test/data/StaggeredElectroMechanicalSimulation.jl
+++ b/test/data/StaggeredElectroMechanicalSimulation.jl
@@ -17,8 +17,8 @@ function staggered_electro_mechanical_simulation(; is_vtk=true, verbose=true)
   partition = (8, 2, 2)
   geometry = CartesianDiscreteModel(domain, partition)
   labels = get_face_labeling(geometry)
-  add_tag_from_tags!(labels, "fixedu", CartesianTags.faceX0)
-  add_tag_from_tags!(labels, "topsuf", CartesianTags.faceZ1)
+  add_tag_from_tags!(labels, "fixedu", CartesianTags.face0YZ⁺)
+  add_tag_from_tags!(labels, "topsuf", CartesianTags.faceXY1⁺)
   add_tag_from_vertex_filter!(labels, geometry, "midsuf", x -> x[3] ≈ 0.001)
 
   # Constitutive model

--- a/test/data/StaggeredViscoElectricSimulation.jl
+++ b/test/data/StaggeredViscoElectricSimulation.jl
@@ -22,8 +22,8 @@ function staggered_visco_electric_simulation(; t_end=2, writevtk=true, verbose=t
   partition = (8, 2, 2)
   geometry = CartesianDiscreteModel(domain, partition)
   labels = get_face_labeling(geometry)
-  add_tag_from_tags!(labels, "fixed", CartesianTags.faceX0)
-  add_tag_from_tags!(labels, "bottom", CartesianTags.faceZ0)
+  add_tag_from_tags!(labels, "fixed", CartesianTags.face0YZ⁺)
+  add_tag_from_tags!(labels, "bottom", CartesianTags.faceXY0⁺)
   add_tag_from_tags!(labels, "top", CartesianTags.faceZ1)
   add_tag_from_vertex_filter!(labels, geometry, "mid", x -> x[3] ≈ 0.5thick)
 

--- a/test/data/StaticMechanicalDirichletSimulation.jl
+++ b/test/data/StaticMechanicalDirichletSimulation.jl
@@ -19,8 +19,8 @@ function static_mechanical_dirichlet_simulation(;writevtk=true, verbose=true)
   thick  = 0.002  # m
   geometry = CartesianDiscreteModel((0, long, 0, width, 0, thick), (5,2,2))
   labels = get_face_labeling(geometry)
-  add_tag_from_tags!(labels, "fixed", CartesianTags.faceX0)
-  add_tag_from_tags!(labels, "moving", CartesianTags.faceX1)
+  add_tag_from_tags!(labels, "fixed", CartesianTags.face0YZ⁺)
+  add_tag_from_tags!(labels, "moving", CartesianTags.face1YZ⁺)
 
   physmodel = MooneyRivlin3D(λ=3.0, μ1=1.0, μ2=0.0, ρ=1.0)
 

--- a/test/data/StaticMechanicalNeumannSimulation.jl
+++ b/test/data/StaticMechanicalNeumannSimulation.jl
@@ -19,8 +19,8 @@ function static_mechanical_neumann_simulation(;writevtk=true, verbose=true)
   thick  = 0.002  # m
   geometry = CartesianDiscreteModel((0, long, 0, width, 0, thick), (5,2,2))
   labels = get_face_labeling(geometry)
-  add_tag_from_tags!(labels, "fixed", CartesianTags.faceX0)
-  add_tag_from_tags!(labels, "force", CartesianTags.faceX1)
+  add_tag_from_tags!(labels, "fixed", CartesianTags.face0YZ⁺)
+  add_tag_from_tags!(labels, "force", CartesianTags.face1YZ⁺)
   
   physmodel = MooneyRivlin3D(λ=3.0, μ1=1.0, μ2=0.0, ρ=1.0)
 

--- a/test/data/ViscoElasticSimulation.jl
+++ b/test/data/ViscoElasticSimulation.jl
@@ -18,8 +18,8 @@ function visco_elastic_simulation(;t_end=15, writevtk=true, verbose=true)
   labels = get_face_labeling(model)
   add_tag_from_tags!(labels, "corner1", CartesianTags.corner000)
   add_tag_from_tags!(labels, "corner2", CartesianTags.corner010)
-  add_tag_from_tags!(labels, "fixed", CartesianTags.faceX0)
-  add_tag_from_tags!(labels, "moving", CartesianTags.faceX1)
+  add_tag_from_tags!(labels, "fixed",  CartesianTags.face0YZ⁺)
+  add_tag_from_tags!(labels, "moving", CartesianTags.face1YZ⁺)
 
   # Constitutive model
   μ = 1.37e4   # Pa


### PR DESCRIPTION
## Changelog
- Face names are now consistent with edges and corners: `faceX0` -> `face0YZ` ~ `edgeX00` ~ `corner000`
- Differentiated raw tags (only corners, edges or faces) and extended tags (face with corners and edges): `face0YZ`, `face0YZ⁺`
- Old names (`faceX0`) have been marked as deprecated to avoid breaking existing code

```diff
- faceX0  # old tag
+ face0YZ  # new name, only contains the face tag
+ face0YZ⁺  # new name, it contains the face with the corresponding edges and corners
+ edgeX00⁺  # extended tag with the corresponding corners
```

## Example

This example shows the usage of the new interface with a quarter domain with symmetry. The simple and extended tags avoid overlapping boundary conditions.

```julia
  domain = (0.0, 0.5width, 0.0, 0.5width, 0.0, thick)
  partition = (ndivisions, ndivisions, ndivisions÷10)
  geometry = CartesianDiscreteModel(domain, partition)
  labels = get_face_labeling(geometry)
  add_tag_from_tags!(labels, "top",    CartesianTags.faceXY1)
  add_tag_from_tags!(labels, "bottom", CartesianTags.faceXY0)
  add_tag_from_tags!(labels, "faces", [CartesianTags.face1YZ⁺; CartesianTags.faceX1Z⁺])
  add_tag_from_tags!(labels, "x_sym", [CartesianTags.face0YZ; CartesianTags.edge0Y0; CartesianTags.edge0Y1])
  add_tag_from_tags!(labels, "y_sym", [CartesianTags.faceX0Z; CartesianTags.edgeX00; CartesianTags.edgeX01])
  add_tag_from_tags!(labels, "center", CartesianTags.edge00Z⁺)
```