### PR TITLE
Reexport TensorValue from Gridap

### DIFF
--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -6,6 +6,8 @@ macro publish(mod, name)
   end
 end
 
+@publish TensorAlgebra TensorValue  # Reexport from Gridap for convenience
+@publish TensorAlgebra VectorValue  # Reexport from Gridap for convenience
 @publish TensorAlgebra (*)
 @publish TensorAlgebra (×ᵢ⁴)
 @publish TensorAlgebra (⊗₁₂³)


### PR DESCRIPTION
This will allow to use TensorValues in short pieces of code without the need of explicitly importing Gridap.