### PR TITLE
Added viscoelastic simulation test

### DIFF
--- a/test/SimulationsTests/ViscoElasticSimulationTest.jl
+++ b/test/SimulationsTests/ViscoElasticSimulationTest.jl
@@ -9,4 +9,4 @@ include(projdir("test/data/ViscoElasticSimulation.jl"))
 
 include(projdir("test/data/ViscoelasticFastSimulation.jl"))
 λx2, σΓ2 = visco_elastic_fast_simulation(t_end=2, writevtk=false, verbose=false)
-@test σΓ2[end] ≈ 21872.5028
+@test σΓ2[end] ≈ 22152.0463

--- a/test/SimulationsTests/ViscoElasticSimulationTest.jl
+++ b/test/SimulationsTests/ViscoElasticSimulationTest.jl
@@ -7,6 +7,6 @@ include(projdir("test/data/ViscoElasticSimulation.jl"))
 @test σΓ[end] ≈ 21872.5028
 
 
-include(projdir("test/data/ViscoelasticFastSimulation.jl"))
+include(projdir("test/data/ViscoElasticFastSimulation.jl"))
 λx2, σΓ2 = visco_elastic_fast_simulation(t_end=2, writevtk=false, verbose=false)
 @test σΓ2[end] ≈ 22152.0463

--- a/test/SimulationsTests/ViscoElasticSimulationTest.jl
+++ b/test/SimulationsTests/ViscoElasticSimulationTest.jl
@@ -1,9 +1,12 @@
 using HyperFEM
 using Test
 
-filename = projdir("test/data/ViscoElasticSimulation.jl")
-include(filename)
 
+include(projdir("test/data/ViscoElasticSimulation.jl"))
 λx, σΓ = visco_elastic_simulation(t_end=2, writevtk=false, verbose=false)
-
 @test σΓ[end] ≈ 21872.5028
+
+
+include(projdir("test/data/ViscoelasticFastSimulation.jl"))
+λx2, σΓ2 = visco_elastic_fast_simulation(t_end=2, writevtk=false, verbose=false)
+@test σΓ2[end] ≈ 21872.5028

--- a/test/data/ViscoElasticFastSimulation.jl
+++ b/test/data/ViscoElasticFastSimulation.jl
@@ -6,7 +6,7 @@ using HyperFEM
 using HyperFEM.DiscreteModeling.EvolutionFunctions
 using HyperFEM.ComputationalModels.PostMetrics
 
-function visco_elastic_simulation(;t_end=15, writevtk=true, verbose=true)
+function visco_elastic_fast_simulation(;t_end=15, writevtk=true, verbose=true)
   # Domain and tessellation
   long   = 0.05   # m
   width  = 0.005  # m
@@ -30,9 +30,9 @@ function visco_elastic_simulation(;t_end=15, writevtk=true, verbose=true)
   μ₃ = 1.98e4  # Pa
   τ₃ = 500.0   # s
   hyper_elastic_model = NeoHookean3D(λ=λ, μ=μ)
-  viscous_branch_1 = ViscousIncompressible(IsochoricNeoHookean3D(μ=μ₁), τ=τ₁)
-  viscous_branch_2 = ViscousIncompressible(IsochoricNeoHookean3D(μ=μ₂), τ=τ₂)
-  viscous_branch_3 = ViscousIncompressible(IsochoricNeoHookean3D(μ=μ₃), τ=τ₃)
+  viscous_branch_1 = ViscousPolyconvex(μ=μ₁, τ=τ₁)
+  viscous_branch_2 = ViscousPolyconvex(μ=μ₂, τ=τ₂)
+  viscous_branch_3 = ViscousPolyconvex(μ=μ₃, τ=τ₃)
   cons_model = GeneralizedMaxwell(hyper_elastic_model, viscous_branch_1, viscous_branch_2, viscous_branch_3)
   k=Kinematics(Mechano,Solid)
 
@@ -95,6 +95,6 @@ end
 
 if abspath(PROGRAM_FILE) == @__FILE__
   using Plots
-  @time  λx, σΓ = visco_elastic_simulation()
+  @time λx, σΓ = visco_elastic_fast_simulation()
   plot(λx, σΓ)
 end


### PR DESCRIPTION
```
Previous model  |  61.084567 seconds (  1.17 G allocations: 91.554 GiB, 15.14% gc time, 0.98% compilation time)
New model       |  11.371305 seconds (189.50 M allocations: 13.800 GiB, 12.98% gc time, 5.31% compilation time)
```

See #199 