### PR TITLE
Updated Visco-Benchmark: equal cost, better syntax

### DIFF
--- a/benchmark/ConstitutiveModelsBenchmark/ViscousModelsBenchmarks.jl
+++ b/benchmark/ConstitutiveModelsBenchmark/ViscousModelsBenchmarks.jl
@@ -5,10 +5,13 @@ using BenchmarkTools
 
 function benchmark_viscous_model()
   elasto = NeoHookean3D(λ=1e6, μ=1e3)
-  visco = ViscousIncompressible(IsochoricNeoHookean3D(μ=1e3), τ=10.)
+  visco = ViscousIncompressible(IsochoricNeoHookean3D(μ=1e2), τ=10.)
+  visco = ViscousIncompressible(IsochoricNeoHookean3D(μ=1e3), τ=1.)
+  visco = ViscousIncompressible(IsochoricNeoHookean3D(μ=1e4), τ=.1)
+  visco = ViscousIncompressible(IsochoricNeoHookean3D(μ=1e5), τ=.01)
   model = GeneralizedMaxwell(elasto, visco)
   update_time_step!(model, 1e-2)
-  Ψ, ∂Ψu, ∂Ψuu = model()
+  Ψ, ∂Ψ∂F, ∂∂Ψ∂FF = model()
   F = TensorValue(1.:9...) * 1e-3 + I3
   Fn = TensorValue(1.:9...) * 5e-4 + I3
   Uvn = TensorValue(1.,2.,3.,2.,4.,5.,3.,5.,6.) * 2e-4 + I3
@@ -17,8 +20,8 @@ function benchmark_viscous_model()
   λvn = 1e-3
   Avn = VectorValue(Uvn..., λvn)
   SUITE["Constitutive models"]["Visco-elastic Ψ"] = @benchmarkable $Ψ($F, $Fn, $Avn)
-  SUITE["Constitutive models"]["Visco-elastic ∂Ψu"] = @benchmarkable $∂Ψu($F, $Fn, $Avn)
-  SUITE["Constitutive models"]["Visco-elastic ∂Ψuu"] = @benchmarkable $∂Ψuu($F, $Fn, $Avn)
+  SUITE["Constitutive models"]["Visco-elastic ∂Ψ∂F"] = @benchmarkable $∂Ψ∂F($F, $Fn, $Avn)
+  SUITE["Constitutive models"]["Visco-elastic ∂∂Ψ∂FF"] = @benchmarkable $∂∂Ψ∂FF($F, $Fn, $Avn)
 end
 
 function benchmark_viscous_polyconvex_model()
@@ -29,7 +32,7 @@ function benchmark_viscous_polyconvex_model()
   visco = ViscousPolyconvex(μ=1e5, τ=.01)
   model = GeneralizedMaxwell(elasto, visco)
   update_time_step!(model, 1e-1)
-  Ψ, ∂Ψu, ∂Ψuu = model()
+  Ψ, ∂Ψ∂F, ∂∂Ψ∂FF = model()
   F = TensorValue(1.:9...) * 1e-2 + I3
   Fn = TensorValue(1.:9...) * 5e-3 + I3
   Cvn = 0.25 * (F+Fn) · (F+Fn)'
@@ -37,8 +40,8 @@ function benchmark_viscous_polyconvex_model()
   Fn /= det(Fn)
   Cvn /= det(Cvn)
   SUITE["Constitutive models"]["Visco-polyconvex Ψ"] = @benchmarkable $Ψ($F, $Fn, $Cvn)
-  SUITE["Constitutive models"]["Visco-polyconvex ∂Ψu"] = @benchmarkable $∂Ψu($F, $Fn, $Cvn)
-  SUITE["Constitutive models"]["Visco-polyconvex ∂Ψuu"] = @benchmarkable $∂Ψuu($F, $Fn, $Cvn)
+  SUITE["Constitutive models"]["Visco-polyconvex ∂Ψ∂F"] = @benchmarkable $∂Ψ∂F($F, $Fn, $Cvn)
+  SUITE["Constitutive models"]["Visco-polyconvex ∂∂Ψ∂FF"] = @benchmarkable $∂∂Ψ∂FF($F, $Fn, $Cvn)
 end
 
 benchmark_viscous_model()


### PR DESCRIPTION
Both models are benchmarked with 4 branches