### PR TITLE
Fixed L2 projection for `TensorValue`

### DIFF
--- a/src/ComputationalModels/PostProcessors.jl
+++ b/src/ComputationalModels/PostProcessors.jl
@@ -195,8 +195,8 @@ end
 
 
 function L2_Projection(u, dΩ, V)
-  a(w, v) = ∫(w · v) * dΩ
-  l(v)    = ∫(v · u) * dΩ
+  a(w, v) = ∫(w ⊙ v) * dΩ
+  l(v)    = ∫(v ⊙ u) * dΩ
   op      = AffineFEOperator(a, l, V, V)
   solve(op)
 end


### PR DESCRIPTION
Replacing `·` by `⊙` is a more generic implementation since the last operator has more overloads:
- scalar: `⊙` -> `*`
- vector: `⊙` -> `·`
- matrix: `⊙` -> `⊙`